### PR TITLE
for #41: start metrics.md doc

### DIFF
--- a/docs/metrics.md
+++ b/docs/metrics.md
@@ -1,0 +1,117 @@
+# METRICS
+
+## Data Analysis
+The collected data will primarily be used to answer the following questions.
+Images are used for visualization and are not composed of actual data.
+
+### Immediate Questions
+
+* Which privacy preferences cause the most/least breakage?
+* On what sites are users reporting the most breakage?
+  * How are those sites broken?
+
+### Follow-up Questions
+
+* How might we fix sites that are reported as broken?
+
+## Data Collection
+
+### Server Side
+There is currently no server side component besides existing Unified Telemtry.
+
+### Client Side
+Study will use SHIELD's Telemetry wrapper with no batching of data.  Details
+of when pings are sent are below, along with examples of the `payload` portion
+of a `shield-study` telemetry ping for each scenario.
+
+#### The user clicks "This page works well" button in the popup
+
+```js
+  {
+    "branch": "thirdPartyCookiesOnlyFromVisited",
+    "originDomain": "www.redditmedia.com",
+    "event": "page-works",
+    "breakage": "",
+    "notes": "",
+    "study_version": "0.0.1",
+    "about": {
+      "_src": "addon",
+      "_v": 2
+    }
+  }
+```
+
+#### The user clicks "Report a problem" button in the popup
+
+```js
+  {
+    "branch": "thirdPartyCookiesOnlyFromVisited",
+    "originDomain": "www.redditmedia.com",
+    "event": "page-problem",
+    "breakage": "",
+    "notes": "",
+    "study_version": "0.0.1",
+    "about": {
+      "_src": "addon",
+      "_v": 2
+    }
+  }
+```
+
+#### The user submits the "There are problems with:" form, which appears after they click the "Report a problem" button
+
+```js
+{
+  "originDomain": "redditmedia.com",
+  "event": "",
+  "breakage": "buttons",
+  "study_version": "0.0.1",
+  "about": {
+    "_src": "addon",
+    "_v": 2
+  }
+}
+```
+
+#### The user submits the "Add a comment" form, which appears after they submit the "There are problems with:" form
+
+```js
+{
+  "originDomain": "redditmedia.com",
+  "event": "",
+  "breakage": "images",
+  "notes": "comment",
+  "study_version": "0.0.1",
+  "about": {
+    "_src": "addon",
+    "_v": 2
+  }
+}
+```
+
+#### The user clicks "Disable privacy study" link
+
+```
+TBD?
+```
+
+A Redshift schema for the payload:
+
+TBD ...
+
+```lua
+local schema = {
+--   column name       field type   length  attributes   field name
+    {"originDomain",   "VARCHAR",   255,    nil,         "Fields[payload.originDomain]"},
+    {"breakage",       "VARCHAR",   255,    nil,         "Fields[payload.breakage]"},
+    {"notes",          "VARCHAR",   10000   nil,         "Fields[payload.notes]"},
+    {"event",          "VARCHAR",   255,    nil,         "Fields[payload.event]"}
+}
+```
+
+Valid data should be enforced on the server side:
+
+TBD
+
+All Mozilla data is kept by default for 180 days and in accordance with our
+privacy policies.

--- a/docs/metrics.md
+++ b/docs/metrics.md
@@ -20,11 +20,15 @@ Images are used for visualization and are not composed of actual data.
 There is currently no server side component besides existing Unified Telemtry.
 
 ### Client Side
-Study will use SHIELD's Telemetry wrapper with no batching of data.  Details
-of when pings are sent are below, along with examples of the `payload` portion
-of a `shield-study` telemetry ping for each scenario.
+Study will use SHIELD's Telemetry wrapper with no batching of data.
 
-#### The user clicks "This page works well" button in the popup
+Clicking the browserAction icon opens a pop-up with panels to report site
+breakage problems. We send Telemetry pings on user events in the pop-up.
+
+Details of when pings are sent are below, along with examples of the `payload`
+portion of a `shield-study` telemetry ping for each scenario.
+
+#### The user clicks "This page works well" button in the pop-up
 
 ```js
   {
@@ -41,7 +45,7 @@ of a `shield-study` telemetry ping for each scenario.
   }
 ```
 
-#### The user clicks "Report a problem" button in the popup
+#### The user clicks "Report a problem" button in the pop-up
 
 ```js
   {

--- a/docs/metrics.md
+++ b/docs/metrics.md
@@ -33,15 +33,10 @@ portion of a `shield-study` telemetry ping for each scenario.
 ```js
   {
     "branch": "thirdPartyCookiesOnlyFromVisited",
-    "originDomain": "www.redditmedia.com",
     "event": "page-works",
+    "originDomain": "www.redditmedia.com",
     "breakage": "",
-    "notes": "",
-    "study_version": "0.0.1",
-    "about": {
-      "_src": "addon",
-      "_v": 2
-    }
+    "notes": ""
   }
 ```
 
@@ -50,15 +45,10 @@ portion of a `shield-study` telemetry ping for each scenario.
 ```js
   {
     "branch": "thirdPartyCookiesOnlyFromVisited",
-    "originDomain": "www.redditmedia.com",
     "event": "page-problem",
+    "originDomain": "www.redditmedia.com",
     "breakage": "",
-    "notes": "",
-    "study_version": "0.0.1",
-    "about": {
-      "_src": "addon",
-      "_v": 2
-    }
+    "notes": ""
   }
 ```
 
@@ -66,14 +56,11 @@ portion of a `shield-study` telemetry ping for each scenario.
 
 ```js
 {
+  "branch": "thirdPartyCookiesOnlyFromVisited",
+  "event": "breakage",
   "originDomain": "redditmedia.com",
-  "event": "",
   "breakage": "buttons",
-  "study_version": "0.0.1",
-  "about": {
-    "_src": "addon",
-    "_v": 2
-  }
+  "notes": ""
 }
 ```
 
@@ -81,41 +68,40 @@ portion of a `shield-study` telemetry ping for each scenario.
 
 ```js
 {
+  "branch": "thirdPartyCookiesOnlyFromVisited",
+  "event": "notes",
   "originDomain": "redditmedia.com",
-  "event": "",
   "breakage": "images",
   "notes": "comment",
-  "study_version": "0.0.1",
-  "about": {
-    "_src": "addon",
-    "_v": 2
-  }
 }
 ```
 
 #### The user clicks "Disable privacy study" link
 
 ```
-TBD?
+{
+  "branch": "thirdPartyCookiesOnlyFromVisited",
+  "originDomain": "redditmedia.com",
+  "event": "disable",
+  "breakage": "",
+  "notes": "",
+}
 ```
 
-A Redshift schema for the payload:
-
-TBD ...
+### A Redshift schema for the payload
 
 ```lua
 local schema = {
 --   column name       field type   length  attributes   field name
+    {"branch",         "VARCHAR",   255,    nil,         "Fields[payload.branch]"},
+    {"event",          "VARCHAR",   255,    nil,         "Fields[payload.event]"},
     {"originDomain",   "VARCHAR",   255,    nil,         "Fields[payload.originDomain]"},
     {"breakage",       "VARCHAR",   255,    nil,         "Fields[payload.breakage]"},
-    {"notes",          "VARCHAR",   10000   nil,         "Fields[payload.notes]"},
-    {"event",          "VARCHAR",   255,    nil,         "Fields[payload.event]"}
+    {"notes",          "VARCHAR",   10000   nil,         "Fields[payload.notes]"}
 }
 ```
 
-Valid data should be enforced on the server side:
-
-TBD
+### Retention
 
 All Mozilla data is kept by default for 180 days and in accordance with our
 privacy policies.

--- a/lib/index.js
+++ b/lib/index.js
@@ -93,7 +93,6 @@ panel.port.on('hostReport', function (message) {
     breakage: '',
     notes: ''
   }
-  console.log('telemetry ping payload: ' + JSON.stringify(telemetryPingMessage))
   shieldUtils.report(telemetryPingMessage)
 });
 
@@ -104,14 +103,16 @@ function getDomainFromActiveTabUrl () {
 function reportBreakageOrNotes (message) {
   let notesSubmission = message.hasOwnProperty('notes');
   let telemetryPingMessage = {
+    branch: study.variation,
     originDomain: getDomainFromActiveTabUrl(),
-    event: '',
-    breakage: message.breakage
+    event: 'breakage',
+    breakage: message.breakage,
+    notes: ''
   }
   if (notesSubmission) {
+    telemetryPingMessage['event'] = 'notes';
     telemetryPingMessage['notes'] = message.notes;
   }
-  console.log('telemetry ping payload: ' + JSON.stringify(telemetryPingMessage))
   shieldUtils.report(telemetryPingMessage)
 }
 
@@ -127,8 +128,16 @@ function handleHide () {
 }
 
 async function disableAddon () {
-  const addon = await AddonManager.getAddonByID(self.id);
-  addon.uninstall();
+  const addon = await AddonManager.getAddonByID(self.id)
+  let telemetryPingMessage = {
+    branch: study.variation,
+    originDomain: getDomainFromActiveTabUrl(),
+    event: 'disable',
+    breakage: '',
+    notes: ''
+  }
+  await shieldUtils.report(telemetryPingMessage)
+  addon.uninstall()
 }
 
 panel.port.on('breakage', reportBreakageOrNotes)


### PR DESCRIPTION
Need @harterrt and/or @ilanasegall to review. Especially the "TBD" sections.

@pdolanjski - you should check this out too.

TODOs:
* [x] `breakage` ping: `branch` and `notes` fields are missing, and `event` is empty
* [x] `comment` ping: `branch` field is missing, and `event` is empty
* [x] Should we send our own `disable` ping in addition to `user-ended-sudy`?