### PR TITLE
for #46: add firstparty.isolate variation(s)

### DIFF
--- a/data/panel/js/popup.js
+++ b/data/panel/js/popup.js
@@ -45,6 +45,16 @@ const breakageRadioOptions = {
     {'value': 'flash', 'label': 'Flash'},
     {'value': 'screen', 'label': 'Window size'},
     {'value': 'other', 'label': 'Something else'}
+  ],
+  'firstPartyIsolation': [
+    {'value': 'login-failure', 'label': 'Could not sign in.'},
+    {'value': 'social-failure', 'label': 'Could not share, like, or tweet.'},
+    {'value': 'other', 'label': 'Something else'}
+  ],
+  'firstPartyIsolationOpenerAccess': [
+    {'value': 'login-failure', 'label': 'Could not sign in.'},
+    {'value': 'social-failure', 'label': 'Could not share, like, or tweet.'},
+    {'value': 'other', 'label': 'Something else'}
   ]
 }
 const searchParams = new URL(window.location).searchParams

--- a/lib/study.js
+++ b/lib/study.js
@@ -21,7 +21,12 @@ const studyConfig = {
     'thirdPartyCookiesOnlyFromVisited': () => feature.studyPref('network.cookie.cookieBehavior', 3),
     'trackingProtection': () => feature.studyPref('privacy.trackingprotection.enabled', true),
     'originOnlyRefererToThirdParties': () => feature.studyPref('network.http.referer.XOriginTrimmingPolicy', 2),
-    'resistFingerprinting': () => feature.studyPref('privacy.resistFingerprinting', true)
+    'resistFingerprinting': () => feature.studyPref('privacy.resistFingerprinting', true),
+    'firstPartyIsolation': () => feature.studyPref('privacy.firstparty.isolate', true),
+    'firstPartyIsolationOpenerAccess': () => {
+      feature.studyPref('privacy.firstparty.isolate', true)
+      feature.studyPref('privacy.firstparty.isolate.restrict_opener_access', false)
+    }
   }
 };
 


### PR DESCRIPTION
Note: this code adds 2 variations to study the breakage levels between restricted opener access (Tor defaults) and unrestricted opener access (new combination).